### PR TITLE
⚡ Bolt: Optimize Next.js Image sizes for fill properties

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Next.js Image fill Performance Bottleneck
+**Learning:** When using Next.js `<Image>` with the `fill` property, omitting the `sizes` attribute causes Next.js to assume the image spans the entire viewport width (`100vw`). In grid or list layouts where the image is actually small, this results in unnecessarily generating and downloading massive image files, severely impacting frontend performance and load times.
+**Action:** Always provide an accurate `sizes` prop when using `fill` on `<Image>` components, especially inside lists, grids, or fixed-width containers. Use responsive media queries in `sizes` to match the CSS layout.

--- a/components/ConveniosHighlight.tsx
+++ b/components/ConveniosHighlight.tsx
@@ -69,6 +69,7 @@ const ConveniosHighlight = () => {
                         src={convenio.logo}
                         alt={`Logo ${convenio.name}`}
                         fill
+                        sizes="80px"
                         className="object-contain"
                       />
                     </div>

--- a/components/equipe/DoctorsCatalog.tsx
+++ b/components/equipe/DoctorsCatalog.tsx
@@ -163,6 +163,7 @@ const DoctorsCatalog = () => {
                     src={doctor.image}
                     alt={doctor.name}
                     fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                     className='object-cover group-hover:scale-110 transition-transform duration-300'
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent'></div>

--- a/components/landing-page/LandingHero.tsx
+++ b/components/landing-page/LandingHero.tsx
@@ -165,6 +165,7 @@ const LandingHero = () => {
                     src="/images/landing-hero.jpg"
                     alt="Agende sua Consulta Oftalmológica - Visual Laser"
                     fill
+                    sizes="(max-width: 1024px) 100vw, 50vw"
                     className="object-cover"
                     priority
                   />


### PR DESCRIPTION
💡 What: Added `sizes` attribute to Next.js `<Image>` components that use the `fill` property in `DoctorsCatalog.tsx`, `LandingHero.tsx`, and `ConveniosHighlight.tsx`.
🎯 Why: Without a `sizes` attribute, Next.js assumes an image with `fill` spans the entire viewport width (`100vw`) and generates `srcset` images accordingly. For grid/list items or small logos, this forces the browser to download unnecessarily massive files, crippling performance and bandwidth.
📊 Impact: Significantly reduces image payload sizes on initial load and scrolling, decreasing Total Blocking Time and Largest Contentful Paint (LCP) in the affected components.
🔬 Measurement: Verify by inspecting the network tab for image sizes on different device widths; they will now fetch much smaller, appropriately-sized variants.

Also created `.jules/bolt.md` to document this Next.js specific performance insight.

---
*PR created automatically by Jules for task [9747474493645257461](https://jules.google.com/task/9747474493645257461) started by @mfelipperd*