### PR TITLE
⚡ Bolt: Add missing sizes prop to Next.js Image components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing sizes prop in Next.js Image components using fill
+**Learning:** Next.js `Image` component with `fill` attribute causes the browser to download the original largest size image at any breakpoint unless `sizes` prop is provided. This happens because the browser does not know the actual visual layout width for the image when calculating dimensions, thus defaults to 100vw, which hurts performance drastically.
+**Action:** Always provide `sizes` prop when using `<Image>` with `fill`. We implemented `sizes` matching the CSS layout size for `LandingHero.tsx`, `DoctorsCatalog.tsx`, and `ConveniosHighlight.tsx` today.

--- a/components/ConveniosHighlight.tsx
+++ b/components/ConveniosHighlight.tsx
@@ -65,11 +65,13 @@ const ConveniosHighlight = () => {
               >
                   {convenio.logo ? (
                     <div className="w-20 h-10 relative mb-3 grayscale group-hover:grayscale-0 transition-all duration-300">
+                      {/* ⚡ Bolt: Added sizes prop to optimize image loading by preventing unnecessary large downloads when fill is used */}
                       <Image 
                         src={convenio.logo}
                         alt={`Logo ${convenio.name}`}
                         fill
                         className="object-contain"
+                        sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 20vw"
                       />
                     </div>
                   ) : (

--- a/components/equipe/DoctorsCatalog.tsx
+++ b/components/equipe/DoctorsCatalog.tsx
@@ -159,11 +159,13 @@ const DoctorsCatalog = () => {
               <div className='bg-white rounded-2xl shadow-xl border border-gray-100 hover:shadow-2xl transition-all duration-300 hover:scale-105 overflow-hidden h-full flex flex-col'>
                 {/* Doctor Image */}
                 <div className='relative h-64 overflow-hidden'>
+                  {/* ⚡ Bolt: Added sizes prop to optimize image loading by preventing unnecessary large downloads when fill is used */}
                   <Image
                     src={doctor.image}
                     alt={doctor.name}
                     fill
                     className='object-cover group-hover:scale-110 transition-transform duration-300'
+                    sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent'></div>
                 </div>

--- a/components/landing-page/LandingHero.tsx
+++ b/components/landing-page/LandingHero.tsx
@@ -161,12 +161,14 @@ const LandingHero = () => {
               <div className="relative">
                 {/* Main Image Container */}
                 <div className="relative rounded-3xl overflow-hidden shadow-2xl aspect-[4/3] md:aspect-auto md:h-[600px]">
+                  {/* ⚡ Bolt: Added sizes prop to optimize image loading by preventing unnecessary large downloads when fill is used */}
                   <Image
                     src="/images/landing-hero.jpg"
                     alt="Agende sua Consulta Oftalmológica - Visual Laser"
                     fill
                     className="object-cover"
                     priority
+                    sizes="(max-width: 1024px) 100vw, 50vw"
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-primary-950/60 via-transparent to-transparent"></div>
                 </div>


### PR DESCRIPTION
💡 **What:** Added `sizes` prop to Next.js `<Image>` components using `fill` layout across multiple components (`LandingHero.tsx`, `DoctorsCatalog.tsx`, `ConveniosHighlight.tsx`).
🎯 **Why:** Without `sizes`, Next.js defaults to assuming the image takes up `100vw`. This forces the browser to unnecessarily download the largest available version of the image even for small containers or mobile devices, severely hurting load time and wasting bandwidth.
📊 **Impact:** Significantly reduces image payload sizes on non-desktop viewports and smaller containers. Browsers will now correctly download optimized images matching the actual visual container size.
🔬 **Measurement:** Open dev tools network tab, test responsive breakpoints on pages with these components (e.g., `/equipe`, landing page). Verify that smaller images are served on mobile devices instead of the full size.

---
*PR created automatically by Jules for task [16729364380612772874](https://jules.google.com/task/16729364380612772874) started by @mfelipperd*