### PR TITLE
⚡ Bolt: Optimize Next.js Image sizes on components with fill

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Next.js Image `fill` Property Anti-Pattern]
+
+**Learning:** Found a specific codebase anti-pattern: using Next.js `<Image>` component with the `fill` property without providing a `sizes` attribute. By default, Next.js will assume the image spans the entire viewport width (`100vw`) and generate a `srcset` with very large images, leading to unnecessary bandwidth usage and hurting LCP performance metrics.
+**Action:** Always provide an explicit `sizes` attribute when using `fill` on `<Image>` to guide the browser in downloading appropriately sized images based on the responsive layout (e.g., `sizes="(max-width: 768px) 100vw, 50vw"`).

--- a/components/ConveniosHighlight.tsx
+++ b/components/ConveniosHighlight.tsx
@@ -69,6 +69,7 @@ const ConveniosHighlight = () => {
                         src={convenio.logo}
                         alt={`Logo ${convenio.name}`}
                         fill
+                        sizes="80px"
                         className="object-contain"
                       />
                     </div>

--- a/components/equipe/DoctorsCatalog.tsx
+++ b/components/equipe/DoctorsCatalog.tsx
@@ -163,6 +163,7 @@ const DoctorsCatalog = () => {
                     src={doctor.image}
                     alt={doctor.name}
                     fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                     className='object-cover group-hover:scale-110 transition-transform duration-300'
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent'></div>

--- a/components/landing-page/LandingHero.tsx
+++ b/components/landing-page/LandingHero.tsx
@@ -165,6 +165,7 @@ const LandingHero = () => {
                     src="/images/landing-hero.jpg"
                     alt="Agende sua Consulta Oftalmológica - Visual Laser"
                     fill
+                    sizes="(max-width: 768px) 100vw, 50vw"
                     className="object-cover"
                     priority
                   />


### PR DESCRIPTION
💡 **What**: Added the `sizes` attribute to Next.js `<Image>` components using the `fill` property in `LandingHero.tsx`, `DoctorsCatalog.tsx`, and `ConveniosHighlight.tsx`.

🎯 **Why**: When the `fill` property is used without `sizes`, Next.js defaults to assuming the image takes up the entire viewport width (`100vw`). This causes the browser to download unnecessarily large image files, even for small elements like logos or grid items, hurting performance metrics like LCP (Largest Contentful Paint).

📊 **Impact**: Reduces total page weight and bandwidth usage by instructing the browser to download appropriately sized images based on the responsive layout. This leads to faster image load times and improved Core Web Vitals.

🔬 **Measurement**: Verify by inspecting network traffic in DevTools; the downloaded image assets for these components will now be significantly smaller than before.

---
*PR created automatically by Jules for task [4085766902862129634](https://jules.google.com/task/4085766902862129634) started by @mfelipperd*