### PR TITLE
⚡ Bolt: Add missing `sizes` attribute to Next.js `Image` components using `fill`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-12 - Next.js Image component FCP/LCP degradation with `fill`
+**Learning:** Using the Next.js `<Image>` component with the `fill` property without providing the `sizes` property will cause the browser to download unnecessarily large image sizes by default (usually 100vw). This leads to significantly degraded FCP (First Contentful Paint) and LCP (Largest Contentful Paint) performance, particularly on mobile devices or when the image is rendered in a much smaller container than 100vw.
+**Action:** When using the Next.js `<Image>` component with the `fill` property, always ensure the `sizes` property is also included with media queries that match the visual constraints of the image across different breakpoints.

--- a/components/ConveniosHighlight.tsx
+++ b/components/ConveniosHighlight.tsx
@@ -69,6 +69,7 @@ const ConveniosHighlight = () => {
                         src={convenio.logo}
                         alt={`Logo ${convenio.name}`}
                         fill
+                        sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 20vw"
                         className="object-contain"
                       />
                     </div>

--- a/components/equipe/DoctorsCatalog.tsx
+++ b/components/equipe/DoctorsCatalog.tsx
@@ -163,6 +163,7 @@ const DoctorsCatalog = () => {
                     src={doctor.image}
                     alt={doctor.name}
                     fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
                     className='object-cover group-hover:scale-110 transition-transform duration-300'
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent'></div>

--- a/components/landing-page/LandingHero.tsx
+++ b/components/landing-page/LandingHero.tsx
@@ -165,6 +165,7 @@ const LandingHero = () => {
                     src="/images/landing-hero.jpg"
                     alt="Agende sua Consulta Oftalmológica - Visual Laser"
                     fill
+                    sizes="(max-width: 768px) 100vw, 50vw"
                     className="object-cover"
                     priority
                   />


### PR DESCRIPTION
💡 **What**: Added `sizes` attribute to `Next.js` `Image` components using the `fill` property in `LandingHero.tsx`, `DoctorsCatalog.tsx`, and `ConveniosHighlight.tsx`. Documented this learning in `.jules/bolt.md`.

🎯 **Why**: When the `fill` property is used without `sizes`, the browser defaults to downloading the image at `100vw`, regardless of the actual rendered size on screen. This results in unnecessarily downloading large image assets.

📊 **Impact**: Reduces FCP (First Contentful Paint) and LCP (Largest Contentful Paint) by only downloading images sized for the current viewport constraints instead of full `100vw`.

🔬 **Measurement**: Inspect the Network tab in DevTools to verify that images smaller than `100vw` are being downloaded on mobile viewports. Run performance tools like Lighthouse or WebPageTest to see improvements in FCP/LCP.

---
*PR created automatically by Jules for task [5882804220330179668](https://jules.google.com/task/5882804220330179668) started by @mfelipperd*