### PR TITLE
⚡ Bolt: [performance improvement] Added Image sizes attribute

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Missing Sizes in Next.js Image Component
+**Learning:** Codebase anti-pattern found: Next.js `<Image>` components using the `fill` property without the `sizes` property cause browsers to download unnecessarily large image sizes.
+**Action:** Always include the `sizes` property when using `fill` in Next.js `<Image>` to define the layout sizes and avoid fetching full-resolution images unnecessarily.

--- a/components/ConveniosHighlight.tsx
+++ b/components/ConveniosHighlight.tsx
@@ -69,6 +69,7 @@ const ConveniosHighlight = () => {
                         src={convenio.logo}
                         alt={`Logo ${convenio.name}`}
                         fill
+                        sizes="80px"
                         className="object-contain"
                       />
                     </div>

--- a/components/equipe/DoctorsCatalog.tsx
+++ b/components/equipe/DoctorsCatalog.tsx
@@ -163,6 +163,7 @@ const DoctorsCatalog = () => {
                     src={doctor.image}
                     alt={doctor.name}
                     fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
                     className='object-cover group-hover:scale-110 transition-transform duration-300'
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent'></div>

--- a/components/landing-page/LandingHero.tsx
+++ b/components/landing-page/LandingHero.tsx
@@ -165,6 +165,7 @@ const LandingHero = () => {
                     src="/images/landing-hero.jpg"
                     alt="Agende sua Consulta Oftalmológica - Visual Laser"
                     fill
+                    sizes="(max-width: 1024px) 100vw, 50vw"
                     className="object-cover"
                     priority
                   />


### PR DESCRIPTION
💡 **What:** Added `sizes` attribute to Next.js `<Image fill />` components where missing.
🎯 **Why:** Codebase anti-pattern found where Next.js `<Image>` components using `fill` without `sizes` caused browsers to fetch unnecessarily large 100vw source images, slowing down the page loads and using more bandwidth.
📊 **Impact:** Reduces unneeded bandwidth transfer for small/medium screen devices and improves Core Web Vitals metric LCP (Largest Contentful Paint).
🔬 **Measurement:** Verify with browser DevTools "Network" tab measuring downloaded image byte size compared to previously downloaded sizes for matching `<Image>` layouts.

Also added a critical learning journal entry reflecting on this codebase-specific anti-pattern.

---
*PR created automatically by Jules for task [13425084931053290666](https://jules.google.com/task/13425084931053290666) started by @mfelipperd*