### PR TITLE
⚡ Bolt: [performance improvement] Add missing `sizes` attribute to Next.js images using `fill`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-15 - [Next.js Image Optimization]
+**Learning:** The codebase has a performance anti-pattern where Next.js `<Image>` components using the `fill` property are frequently missing the `sizes` property. Without `sizes`, Next.js defaults to generating a `srcset` for `100vw`, which forces users to download unnecessarily large images, worsening Largest Contentful Paint (LCP) and wasting bandwidth.
+**Action:** When using `<Image fill>`, always explicitly define the `sizes` attribute based on the parent container's size at different breakpoints.

--- a/components/ConveniosHighlight.tsx
+++ b/components/ConveniosHighlight.tsx
@@ -1,52 +1,51 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { Shield, ArrowRight } from "lucide-react";
-import Link from "next/link";
+import { motion } from 'framer-motion';
+import { Shield, ArrowRight } from 'lucide-react';
+import Link from 'next/link';
 
-import Image from "next/image";
+import Image from 'next/image';
 
 const convenios = [
-  { name: "Unimed", logo: "/images/convenios/unimed.svg" },
-  { name: "Bradesco Saúde", logo: "/images/convenios/bradesco.png" },
-  { name: "SulAmérica", logo: null },
-  { name: "CASSI", logo: "/images/convenios/cassi.webp" },
-  { name: "Petrobras", logo: "/images/convenios/petrobras.svg" },
-  { name: "Eletronorte", logo: "/images/convenios/eletronorte_new.png" },
-  { name: "Correios", logo: "/images/convenios/correios.png" },
-  { name: "Amil", logo: "/images/convenios/amil.svg" },
-  { name: "Vale (PASA)", logo: null },
-  { name: "Saúde Caixa", logo: null }
+  { name: 'Unimed', logo: '/images/convenios/unimed.svg' },
+  { name: 'Bradesco Saúde', logo: '/images/convenios/bradesco.png' },
+  { name: 'SulAmérica', logo: null },
+  { name: 'CASSI', logo: '/images/convenios/cassi.webp' },
+  { name: 'Petrobras', logo: '/images/convenios/petrobras.svg' },
+  { name: 'Eletronorte', logo: '/images/convenios/eletronorte_new.png' },
+  { name: 'Correios', logo: '/images/convenios/correios.png' },
+  { name: 'Amil', logo: '/images/convenios/amil.svg' },
+  { name: 'Vale (PASA)', logo: null },
+  { name: 'Saúde Caixa', logo: null },
 ];
 
 const ConveniosHighlight = () => {
   return (
-    <section className="section-padding bg-gray-50 overflow-x-hidden">
-      <div className="container mx-auto container-padding">
-        <div className="max-w-4xl mx-auto">
-          
+    <section className='section-padding bg-gray-50 overflow-x-hidden'>
+      <div className='container mx-auto container-padding'>
+        <div className='max-w-4xl mx-auto'>
           {/* Header */}
           <motion.div
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.8 }}
-            className="text-center mb-12"
+            className='text-center mb-12'
           >
-            <div className="inline-flex items-center space-x-2 bg-white rounded-full px-6 py-2 mb-6 border border-gray-100 shadow-sm">
-              <Shield className="w-5 h-5 text-accent-500" />
-              <span className="text-sm font-medium text-gray-600">
+            <div className='inline-flex items-center space-x-2 bg-white rounded-full px-6 py-2 mb-6 border border-gray-100 shadow-sm'>
+              <Shield className='w-5 h-5 text-accent-500' />
+              <span className='text-sm font-medium text-gray-600'>
                 Planos de Saúde
               </span>
             </div>
-            
-            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
-              Convênios <span className="text-gradient">Atendidos</span>
+
+            <h2 className='text-3xl md:text-4xl font-bold text-gray-900 mb-6'>
+              Convênios <span className='text-gradient'>Atendidos</span>
             </h2>
-            
-            <p className="text-xl text-gray-600 leading-relaxed">
-              Trabalhamos com os principais planos de saúde para garantir 
-              que você tenha acesso ao melhor atendimento oftalmológico.
+
+            <p className='text-xl text-gray-600 leading-relaxed'>
+              Trabalhamos com os principais planos de saúde para garantir que
+              você tenha acesso ao melhor atendimento oftalmológico.
             </p>
           </motion.div>
 
@@ -56,28 +55,29 @@ const ConveniosHighlight = () => {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.8, delay: 0.2 }}
-            className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4 mb-12"
+            className='grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4 mb-12'
           >
             {convenios.map((convenio, index) => (
               <div
                 key={index}
-                className="bg-white rounded-xl p-4 flex flex-col items-center justify-center text-center border border-gray-100 shadow-sm hover:shadow-md hover:border-accent-200 transition-all duration-300 group h-32"
+                className='bg-white rounded-xl p-4 flex flex-col items-center justify-center text-center border border-gray-100 shadow-sm hover:shadow-md hover:border-accent-200 transition-all duration-300 group h-32'
               >
-                  {convenio.logo ? (
-                    <div className="w-20 h-10 relative mb-3 grayscale group-hover:grayscale-0 transition-all duration-300">
-                      <Image 
-                        src={convenio.logo}
-                        alt={`Logo ${convenio.name}`}
-                        fill
-                        className="object-contain"
-                      />
-                    </div>
-                  ) : (
-                    <div className="w-10 h-10 rounded-full bg-gray-50 flex items-center justify-center mb-2 group-hover:bg-accent-50 transition-colors">
-                        <Shield className="w-5 h-5 text-gray-400 group-hover:text-accent-500 transition-colors" />
-                    </div>
-                  )}
-                <span className="text-sm font-medium text-gray-700 group-hover:text-accent-900">
+                {convenio.logo ? (
+                  <div className='w-20 h-10 relative mb-3 grayscale group-hover:grayscale-0 transition-all duration-300'>
+                    <Image
+                      src={convenio.logo}
+                      alt={`Logo ${convenio.name}`}
+                      fill
+                      sizes='(max-width: 640px) 50vw, (max-width: 768px) 33vw, 20vw'
+                      className='object-contain'
+                    />
+                  </div>
+                ) : (
+                  <div className='w-10 h-10 rounded-full bg-gray-50 flex items-center justify-center mb-2 group-hover:bg-accent-50 transition-colors'>
+                    <Shield className='w-5 h-5 text-gray-400 group-hover:text-accent-500 transition-colors' />
+                  </div>
+                )}
+                <span className='text-sm font-medium text-gray-700 group-hover:text-accent-900'>
                   {convenio.name}
                 </span>
               </div>
@@ -90,17 +90,16 @@ const ConveniosHighlight = () => {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.8, delay: 0.4 }}
-            className="text-center"
+            className='text-center'
           >
             <Link
-              href="/convenios"
-              className="inline-flex items-center space-x-2 text-accent-600 font-semibold hover:text-accent-700 hover:translate-x-1 transition-all"
+              href='/convenios'
+              className='inline-flex items-center space-x-2 text-accent-600 font-semibold hover:text-accent-700 hover:translate-x-1 transition-all'
             >
               <span>Ver lista completa de convênios</span>
-              <ArrowRight className="w-5 h-5" />
+              <ArrowRight className='w-5 h-5' />
             </Link>
           </motion.div>
-
         </div>
       </div>
     </section>

--- a/components/equipe/DoctorsCatalog.tsx
+++ b/components/equipe/DoctorsCatalog.tsx
@@ -163,6 +163,7 @@ const DoctorsCatalog = () => {
                     src={doctor.image}
                     alt={doctor.name}
                     fill
+                    sizes='(max-width: 640px) 100vw, (max-width: 768px) 50vw, 33vw'
                     className='object-cover group-hover:scale-110 transition-transform duration-300'
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent'></div>

--- a/components/landing-page/LandingHero.tsx
+++ b/components/landing-page/LandingHero.tsx
@@ -1,17 +1,16 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { ArrowRight, Clock, Shield, Users } from "lucide-react";
-import Image from "next/image";
+import { motion } from 'framer-motion';
+import { ArrowRight, Clock, Shield, Users } from 'lucide-react';
+import Image from 'next/image';
 
 const LandingHero = () => {
-
   const handleCTAClick = () => {
     // Rastrear evento de clique no CTA principal
     if (typeof window !== 'undefined' && window.trackConversion) {
       window.trackConversion('Lead');
     }
-    
+
     // Scroll para o formulário
     const formElement = document.getElementById('landing-form');
     if (formElement) {
@@ -20,33 +19,35 @@ const LandingHero = () => {
   };
 
   return (
-    <section id="hero" className="relative min-h-screen bg-gradient-to-br from-primary-950 via-primary-900 to-primary-950 overflow-hidden">
+    <section
+      id='hero'
+      className='relative min-h-screen bg-gradient-to-br from-primary-950 via-primary-900 to-primary-950 overflow-hidden'
+    >
       {/* Background Pattern */}
-      <div className="absolute inset-0 opacity-10">
+      <div className='absolute inset-0 opacity-10'>
         <div className="absolute inset-0 bg-[url('/images/hero-pattern.svg')] bg-repeat"></div>
       </div>
 
       {/* Hero Content */}
-      <div className="relative z-10 container mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16">
-        <div className="max-w-7xl mx-auto">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center min-h-[80vh]">
-            
+      <div className='relative z-10 container mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16'>
+        <div className='max-w-7xl mx-auto'>
+          <div className='grid grid-cols-1 lg:grid-cols-2 gap-12 items-center min-h-[80vh]'>
             {/* Left Column - Content */}
             <motion.div
               initial={{ opacity: 0, x: -50 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.8 }}
-              className="text-white space-y-8"
+              className='text-white space-y-8'
             >
               {/* Badge */}
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 }}
-                className="inline-flex items-center space-x-2 bg-accent-500/20 backdrop-blur-sm rounded-full px-6 py-3 border border-accent-400/30"
+                className='inline-flex items-center space-x-2 bg-accent-500/20 backdrop-blur-sm rounded-full px-6 py-3 border border-accent-400/30'
               >
-                <Clock className="w-5 h-5 text-accent-400" />
-                <span className="text-sm font-medium text-accent-300">
+                <Clock className='w-5 h-5 text-accent-400' />
+                <span className='text-sm font-medium text-accent-300'>
                   Agendamento Online - Fácil e Rápido!
                 </span>
               </motion.div>
@@ -56,20 +57,22 @@ const LandingHero = () => {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.4 }}
-                className="space-y-6"
+                className='space-y-6'
               >
-                <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight">
-                  <span className="text-gradient bg-gradient-to-r from-white to-accent-300 bg-clip-text text-transparent">
+                <h1 className='text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight'>
+                  <span className='text-gradient bg-gradient-to-r from-white to-accent-300 bg-clip-text text-transparent'>
                     Agende sua
                   </span>
                   <br />
-                  <span className="text-white">Consulta</span>
+                  <span className='text-white'>Consulta</span>
                   <br />
-                  <span className="text-accent-400">Oftalmológica</span>
+                  <span className='text-accent-400'>Oftalmológica</span>
                 </h1>
-                
-                <p className="text-xl lg:text-2xl text-primary-200 leading-relaxed max-w-2xl">
-                  👁️ <strong>Agende agora</strong> sua consulta oftalmológica com especialistas experientes e tecnologia de última geração em Belém.
+
+                <p className='text-xl lg:text-2xl text-primary-200 leading-relaxed max-w-2xl'>
+                  👁️ <strong>Agende agora</strong> sua consulta oftalmológica
+                  com especialistas experientes e tecnologia de última geração
+                  em Belém.
                 </p>
               </motion.div>
 
@@ -78,31 +81,39 @@ const LandingHero = () => {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.6 }}
-                className="space-y-4"
+                className='space-y-4'
               >
-                <div className="flex items-center space-x-3">
-                  <div className="w-6 h-6 bg-accent-500 rounded-full flex items-center justify-center">
-                    <div className="w-2 h-2 bg-white rounded-full"></div>
+                <div className='flex items-center space-x-3'>
+                  <div className='w-6 h-6 bg-accent-500 rounded-full flex items-center justify-center'>
+                    <div className='w-2 h-2 bg-white rounded-full'></div>
                   </div>
-                  <span className="text-lg text-white">✅ Agendamento online fácil</span>
+                  <span className='text-lg text-white'>
+                    ✅ Agendamento online fácil
+                  </span>
                 </div>
-                <div className="flex items-center space-x-3">
-                  <div className="w-6 h-6 bg-accent-500 rounded-full flex items-center justify-center">
-                    <div className="w-2 h-2 bg-white rounded-full"></div>
+                <div className='flex items-center space-x-3'>
+                  <div className='w-6 h-6 bg-accent-500 rounded-full flex items-center justify-center'>
+                    <div className='w-2 h-2 bg-white rounded-full'></div>
                   </div>
-                  <span className="text-lg text-white">✅ Oftalmologistas especializados</span>
+                  <span className='text-lg text-white'>
+                    ✅ Oftalmologistas especializados
+                  </span>
                 </div>
-                <div className="flex items-center space-x-3">
-                  <div className="w-6 h-6 bg-accent-500 rounded-full flex items-center justify-center">
-                    <div className="w-2 h-2 bg-white rounded-full"></div>
+                <div className='flex items-center space-x-3'>
+                  <div className='w-6 h-6 bg-accent-500 rounded-full flex items-center justify-center'>
+                    <div className='w-2 h-2 bg-white rounded-full'></div>
                   </div>
-                  <span className="text-lg text-white">✅ Tecnologia de última geração</span>
+                  <span className='text-lg text-white'>
+                    ✅ Tecnologia de última geração
+                  </span>
                 </div>
-                <div className="flex items-center space-x-3">
-                  <div className="w-6 h-6 bg-accent-500 rounded-full flex items-center justify-center">
-                    <div className="w-2 h-2 bg-white rounded-full"></div>
+                <div className='flex items-center space-x-3'>
+                  <div className='w-6 h-6 bg-accent-500 rounded-full flex items-center justify-center'>
+                    <div className='w-2 h-2 bg-white rounded-full'></div>
                   </div>
-                  <span className="text-lg text-white">✅ Atendimento humanizado</span>
+                  <span className='text-lg text-white'>
+                    ✅ Atendimento humanizado
+                  </span>
                 </div>
               </motion.div>
 
@@ -111,21 +122,26 @@ const LandingHero = () => {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.8 }}
-                className="flex flex-col sm:flex-row gap-4 pt-6"
+                className='flex flex-col sm:flex-row gap-4 pt-6'
               >
                 <button
                   onClick={handleCTAClick}
-                  className="group inline-flex items-center justify-center space-x-3 bg-accent-500 hover:bg-accent-600 text-white font-bold py-6 px-8 rounded-2xl transition-all duration-300 transform hover:scale-105 shadow-2xl"
+                  className='group inline-flex items-center justify-center space-x-3 bg-accent-500 hover:bg-accent-600 text-white font-bold py-6 px-8 rounded-2xl transition-all duration-300 transform hover:scale-105 shadow-2xl'
                 >
-                  <span className="text-xl">🎯 Agendar Consulta</span>
-                  <ArrowRight className="w-6 h-6 group-hover:translate-x-1 transition-transform duration-200" />
+                  <span className='text-xl'>🎯 Agendar Consulta</span>
+                  <ArrowRight className='w-6 h-6 group-hover:translate-x-1 transition-transform duration-200' />
                 </button>
-                
+
                 <button
-                  onClick={() => window.open('https://wa.me/5591988968201?text=Quero%20agendar%20uma%20consulta%20oftalmológica', '_blank')}
-                  className="inline-flex items-center justify-center space-x-3 bg-white/10 hover:bg-white/20 text-white font-semibold py-6 px-8 rounded-2xl transition-all duration-300 border border-white/30 hover:border-white/50 backdrop-blur-sm"
+                  onClick={() =>
+                    window.open(
+                      'https://wa.me/5591988968201?text=Quero%20agendar%20uma%20consulta%20oftalmológica',
+                      '_blank'
+                    )
+                  }
+                  className='inline-flex items-center justify-center space-x-3 bg-white/10 hover:bg-white/20 text-white font-semibold py-6 px-8 rounded-2xl transition-all duration-300 border border-white/30 hover:border-white/50 backdrop-blur-sm'
                 >
-                  <span className="text-lg">💬 Falar no WhatsApp</span>
+                  <span className='text-lg'>💬 Falar no WhatsApp</span>
                 </button>
               </motion.div>
 
@@ -134,19 +150,25 @@ const LandingHero = () => {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 1 }}
-                className="flex flex-wrap items-center gap-6 pt-8"
+                className='flex flex-wrap items-center gap-6 pt-8'
               >
-                <div className="flex items-center space-x-2">
-                  <Shield className="w-5 h-5 text-accent-400" />
-                  <span className="text-sm text-primary-200">Dados Seguros</span>
+                <div className='flex items-center space-x-2'>
+                  <Shield className='w-5 h-5 text-accent-400' />
+                  <span className='text-sm text-primary-200'>
+                    Dados Seguros
+                  </span>
                 </div>
-                <div className="flex items-center space-x-2">
-                  <Users className="w-5 h-5 text-accent-400" />
-                  <span className="text-sm text-primary-200">50.000+ Pacientes</span>
+                <div className='flex items-center space-x-2'>
+                  <Users className='w-5 h-5 text-accent-400' />
+                  <span className='text-sm text-primary-200'>
+                    50.000+ Pacientes
+                  </span>
                 </div>
-                <div className="flex items-center space-x-2">
-                  <Clock className="w-5 h-5 text-accent-400" />
-                  <span className="text-sm text-primary-200">+25 Anos Experiência</span>
+                <div className='flex items-center space-x-2'>
+                  <Clock className='w-5 h-5 text-accent-400' />
+                  <span className='text-sm text-primary-200'>
+                    +25 Anos Experiência
+                  </span>
                 </div>
               </motion.div>
             </motion.div>
@@ -156,19 +178,20 @@ const LandingHero = () => {
               initial={{ opacity: 0, x: 50 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.8, delay: 0.2 }}
-              className="relative"
+              className='relative'
             >
-              <div className="relative">
+              <div className='relative'>
                 {/* Main Image Container */}
-                <div className="relative rounded-3xl overflow-hidden shadow-2xl aspect-[4/3] md:aspect-auto md:h-[600px]">
+                <div className='relative rounded-3xl overflow-hidden shadow-2xl aspect-[4/3] md:aspect-auto md:h-[600px]'>
                   <Image
-                    src="/images/landing-hero.jpg"
-                    alt="Agende sua Consulta Oftalmológica - Visual Laser"
+                    src='/images/landing-hero.jpg'
+                    alt='Agende sua Consulta Oftalmológica - Visual Laser'
                     fill
-                    className="object-cover"
+                    sizes='(max-width: 768px) 100vw, 50vw'
+                    className='object-cover'
                     priority
                   />
-                  <div className="absolute inset-0 bg-gradient-to-t from-primary-950/60 via-transparent to-transparent"></div>
+                  <div className='absolute inset-0 bg-gradient-to-t from-primary-950/60 via-transparent to-transparent'></div>
                 </div>
 
                 {/* Floating Cards */}
@@ -176,19 +199,24 @@ const LandingHero = () => {
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: 1, duration: 0.6 }}
-                  className="absolute -bottom-6 -left-6 bg-white rounded-2xl p-6 shadow-xl max-w-xs"
+                  className='absolute -bottom-6 -left-6 bg-white rounded-2xl p-6 shadow-xl max-w-xs'
                 >
-                  <div className="flex items-center space-x-3 mb-3">
-                    <div className="w-12 h-12 bg-accent-500 rounded-xl flex items-center justify-center">
-                      <Users className="w-6 h-6 text-white" />
+                  <div className='flex items-center space-x-3 mb-3'>
+                    <div className='w-12 h-12 bg-accent-500 rounded-xl flex items-center justify-center'>
+                      <Users className='w-6 h-6 text-white' />
                     </div>
                     <div>
-                      <h3 className="text-lg font-bold text-gray-900">Equipe Especializada</h3>
-                      <p className="text-sm text-gray-600">Médicos experientes</p>
+                      <h3 className='text-lg font-bold text-gray-900'>
+                        Equipe Especializada
+                      </h3>
+                      <p className='text-sm text-gray-600'>
+                        Médicos experientes
+                      </p>
                     </div>
                   </div>
-                  <p className="text-sm text-gray-600">
-                    Nossa equipe de oftalmologistas possui mais de 25 anos de experiência em Belém.
+                  <p className='text-sm text-gray-600'>
+                    Nossa equipe de oftalmologistas possui mais de 25 anos de
+                    experiência em Belém.
                   </p>
                 </motion.div>
 
@@ -196,19 +224,24 @@ const LandingHero = () => {
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: 1.2, duration: 0.6 }}
-                  className="absolute -top-6 -right-6 bg-white rounded-2xl p-6 shadow-xl max-w-xs"
+                  className='absolute -top-6 -right-6 bg-white rounded-2xl p-6 shadow-xl max-w-xs'
                 >
-                  <div className="flex items-center space-x-3 mb-3">
-                    <div className="w-12 h-12 bg-primary-600 rounded-xl flex items-center justify-center">
-                      <Shield className="w-6 h-6 text-white" />
+                  <div className='flex items-center space-x-3 mb-3'>
+                    <div className='w-12 h-12 bg-primary-600 rounded-xl flex items-center justify-center'>
+                      <Shield className='w-6 h-6 text-white' />
                     </div>
                     <div>
-                      <h3 className="text-lg font-bold text-gray-900">Tecnologia Avançada</h3>
-                      <p className="text-sm text-gray-600">Equipamentos modernos</p>
+                      <h3 className='text-lg font-bold text-gray-900'>
+                        Tecnologia Avançada
+                      </h3>
+                      <p className='text-sm text-gray-600'>
+                        Equipamentos modernos
+                      </p>
                     </div>
                   </div>
-                  <p className="text-sm text-gray-600">
-                    Utilizamos os mais modernos equipamentos para diagnósticos precisos.
+                  <p className='text-sm text-gray-600'>
+                    Utilizamos os mais modernos equipamentos para diagnósticos
+                    precisos.
                   </p>
                 </motion.div>
               </div>
@@ -222,13 +255,13 @@ const LandingHero = () => {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 1.5 }}
-        className="absolute bottom-8 left-1/2 transform -translate-x-1/2"
+        className='absolute bottom-8 left-1/2 transform -translate-x-1/2'
       >
-        <div className="w-6 h-10 border-2 border-white/30 rounded-full flex justify-center">
+        <div className='w-6 h-10 border-2 border-white/30 rounded-full flex justify-center'>
           <motion.div
             animate={{ y: [0, 12, 0] }}
             transition={{ duration: 2, repeat: Infinity }}
-            className="w-1 h-3 bg-white/60 rounded-full mt-2"
+            className='w-1 h-3 bg-white/60 rounded-full mt-2'
           />
         </div>
       </motion.div>


### PR DESCRIPTION
💡 What: Added the `sizes` attribute to several Next.js `<Image>` components that use the `fill` property across `LandingHero`, `DoctorsCatalog`, and `ConveniosHighlight`.

🎯 Why: The Next.js `<Image>` component, when used with `fill`, requires a `sizes` attribute to tell the browser how large the image will be at different breakpoints. Without it, Next.js defaults to assuming the image will take up `100vw` (the full width of the screen). This forces the browser to download a unnecessarily large, unoptimized image, which worsens Largest Contentful Paint (LCP) and increases bandwidth consumption.

📊 Impact: Significantly reduces the amount of data downloaded for images on the landing page, doctors catalog, and convenios highlight section. This should result in a faster LCP and lower memory footprint, particularly on mobile devices.

🔬 Measurement: Check the Network tab in DevTools when loading the affected pages on a mobile viewport. The browser will now download appropriately sized image assets (e.g. 640px, 768px wide) instead of full-resolution desktop images.

---
*PR created automatically by Jules for task [16214950531385617990](https://jules.google.com/task/16214950531385617990) started by @mfelipperd*