### PR TITLE
⚡ Bolt: [performance improvement] Add sizes property to filled images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-16 - [Frontend Optimization] Missing sizes property on filled Images
+**Learning:** When using Next.js `<Image>` component with the `fill` property, omitting the `sizes` attribute causes Next.js to default to `100vw`. This leads the browser to download unnecessarily massive image versions even for small containers (like an 80px logo inside a grid), severely impacting bandwidth and Largest Contentful Paint (LCP).
+**Action:** Always ensure the `sizes` property is included when using `<Image fill />`. Base the sizes string on the actual rendered container width at various breakpoints.

--- a/components/ConveniosHighlight.tsx
+++ b/components/ConveniosHighlight.tsx
@@ -70,6 +70,7 @@ const ConveniosHighlight = () => {
                         alt={`Logo ${convenio.name}`}
                         fill
                         className="object-contain"
+                        sizes="80px"
                       />
                     </div>
                   ) : (

--- a/components/equipe/DoctorsCatalog.tsx
+++ b/components/equipe/DoctorsCatalog.tsx
@@ -164,6 +164,7 @@ const DoctorsCatalog = () => {
                     alt={doctor.name}
                     fill
                     className='object-cover group-hover:scale-110 transition-transform duration-300'
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent'></div>
                 </div>

--- a/components/landing-page/LandingHero.tsx
+++ b/components/landing-page/LandingHero.tsx
@@ -167,6 +167,7 @@ const LandingHero = () => {
                     fill
                     className="object-cover"
                     priority
+                    sizes="(max-width: 768px) 100vw, 50vw"
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-primary-950/60 via-transparent to-transparent"></div>
                 </div>


### PR DESCRIPTION
**💡 What:** 
Added the `sizes` property to Next.js `<Image>` components that use the `fill` layout property in `ConveniosHighlight`, `LandingHero`, and `DoctorsCatalog`. 

**🎯 Why:** 
When using the Next.js `<Image>` component with the `fill` property, omitting the `sizes` attribute causes Next.js to default to `100vw`. This forces the browser to download unnecessarily massive image versions (e.g. for an 80px logo inside a grid, it might download a 1080p image on desktop). This severely impacts bandwidth, memory, and LCP (Largest Contentful Paint).

**📊 Impact:** 
- Reduces image payload size significantly, especially for elements like logos in `ConveniosHighlight` and cards in `DoctorsCatalog`.
- Faster visual load time and improved LCP.
- Less bandwidth usage for mobile and desktop users.

**🔬 Measurement:** 
1. Build the application (`npm run build` & `npm run start`).
2. Open DevTools Network tab.
3. Compare the downloaded file size of images in the `Convenios` section and `Equipe` section before and after this change. They should be drastically smaller.

---
*PR created automatically by Jules for task [12232478672227504369](https://jules.google.com/task/12232478672227504369) started by @mfelipperd*