### PR TITLE
⚡ Bolt: [performance improvement] Add sizes attribute to Next.js Image components with fill

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Unoptimized Next.js Images with Fill]
+**Learning:** Found multiple instances of the `<Image fill />` pattern without the `sizes` attribute. By default, Next.js assumes images with `fill` take up `100vw`, downloading massive image variants even for small containers (like logos fixed at 80px width).
+**Action:** Always verify `<Image fill />` includes an accurate `sizes` prop mapped to the container's rendered size. When container sizes are fixed, provide absolute pixel values (e.g. `sizes="80px"`). When responsive, provide precise viewport-based queries.

--- a/components/ConveniosHighlight.tsx
+++ b/components/ConveniosHighlight.tsx
@@ -65,10 +65,12 @@ const ConveniosHighlight = () => {
               >
                   {convenio.logo ? (
                     <div className="w-20 h-10 relative mb-3 grayscale group-hover:grayscale-0 transition-all duration-300">
+                      {/* Optimization: Added sizes property to prevent downloading unnecessarily large images when using fill */}
                       <Image 
                         src={convenio.logo}
                         alt={`Logo ${convenio.name}`}
                         fill
+                        sizes="80px"
                         className="object-contain"
                       />
                     </div>

--- a/components/equipe/DoctorsCatalog.tsx
+++ b/components/equipe/DoctorsCatalog.tsx
@@ -159,10 +159,12 @@ const DoctorsCatalog = () => {
               <div className='bg-white rounded-2xl shadow-xl border border-gray-100 hover:shadow-2xl transition-all duration-300 hover:scale-105 overflow-hidden h-full flex flex-col'>
                 {/* Doctor Image */}
                 <div className='relative h-64 overflow-hidden'>
+                  {/* Optimization: Added sizes property to prevent downloading unnecessarily large images when using fill */}
                   <Image
                     src={doctor.image}
                     alt={doctor.name}
                     fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
                     className='object-cover group-hover:scale-110 transition-transform duration-300'
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent'></div>

--- a/components/landing-page/LandingHero.tsx
+++ b/components/landing-page/LandingHero.tsx
@@ -161,10 +161,12 @@ const LandingHero = () => {
               <div className="relative">
                 {/* Main Image Container */}
                 <div className="relative rounded-3xl overflow-hidden shadow-2xl aspect-[4/3] md:aspect-auto md:h-[600px]">
+                  {/* Optimization: Added sizes property to prevent downloading unnecessarily large images when using fill */}
                   <Image
                     src="/images/landing-hero.jpg"
                     alt="Agende sua Consulta Oftalmológica - Visual Laser"
                     fill
+                    sizes="(max-width: 1024px) 100vw, 50vw"
                     className="object-cover"
                     priority
                   />


### PR DESCRIPTION
💡 **What:** Added the `sizes` attribute to several Next.js `<Image>` components that were using the `fill` property without it (`components/ConveniosHighlight.tsx`, `components/landing-page/LandingHero.tsx`, `components/equipe/DoctorsCatalog.tsx`).
🎯 **Why:** Without a `sizes` attribute, Next.js assumes images using `fill` will be displayed at 100vw, forcing browsers to download unnecessarily large, high-resolution versions of images, even when they are rendered in small containers (e.g., an 80px wide logo).
📊 **Impact:** Reduces the total image payload and improves LCP (Largest Contentful Paint) by ensuring browsers only download the appropriately sized image for the viewport and container.
🔬 **Measurement:** Verify via Chrome DevTools Network panel that smaller image file sizes are being downloaded for these components compared to before, especially on mobile or for the small partner logos.

---
*PR created automatically by Jules for task [11149879037065191528](https://jules.google.com/task/11149879037065191528) started by @mfelipperd*