### PR TITLE
⚡ Bolt: [performance improvement] Add sizes to next/image to reduce LCP and bandwidth

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - [Next.js Image Sizes Optimization]
+**Learning:** Missing sizes property on <Image fill /> components forces the browser to download unnecessarily large image sizes, leading to wasted bandwidth and slower load times.
+**Action:** Always provide appropriate sizes property when using fill to ensure optimal responsive image loading.

--- a/components/ConveniosHighlight.tsx
+++ b/components/ConveniosHighlight.tsx
@@ -65,10 +65,12 @@ const ConveniosHighlight = () => {
               >
                   {convenio.logo ? (
                     <div className="w-20 h-10 relative mb-3 grayscale group-hover:grayscale-0 transition-all duration-300">
+                      {/* ⚡ Bolt: added sizes prop to optimize LCP and bandwidth */}
                       <Image 
                         src={convenio.logo}
                         alt={`Logo ${convenio.name}`}
                         fill
+                        sizes="(max-width: 768px) 5rem, 5rem"
                         className="object-contain"
                       />
                     </div>

--- a/components/equipe/DoctorsCatalog.tsx
+++ b/components/equipe/DoctorsCatalog.tsx
@@ -159,10 +159,12 @@ const DoctorsCatalog = () => {
               <div className='bg-white rounded-2xl shadow-xl border border-gray-100 hover:shadow-2xl transition-all duration-300 hover:scale-105 overflow-hidden h-full flex flex-col'>
                 {/* Doctor Image */}
                 <div className='relative h-64 overflow-hidden'>
+                  {/* ⚡ Bolt: added sizes prop to optimize LCP and bandwidth */}
                   <Image
                     src={doctor.image}
                     alt={doctor.name}
                     fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                     className='object-cover group-hover:scale-110 transition-transform duration-300'
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent'></div>

--- a/components/landing-page/LandingHero.tsx
+++ b/components/landing-page/LandingHero.tsx
@@ -161,10 +161,12 @@ const LandingHero = () => {
               <div className="relative">
                 {/* Main Image Container */}
                 <div className="relative rounded-3xl overflow-hidden shadow-2xl aspect-[4/3] md:aspect-auto md:h-[600px]">
+                  {/* ⚡ Bolt: added sizes prop to optimize LCP and bandwidth */}
                   <Image
                     src="/images/landing-hero.jpg"
                     alt="Agende sua Consulta Oftalmológica - Visual Laser"
                     fill
+                    sizes="(max-width: 768px) 100vw, 50vw"
                     className="object-cover"
                     priority
                   />


### PR DESCRIPTION
### 💡 What:
Added the `sizes` property to Next.js `<Image>` components that use the `fill` prop across several files (`ConveniosHighlight.tsx`, `DoctorsCatalog.tsx`, and `LandingHero.tsx`). Created `.jules/bolt.md` to record the learning about this Next.js image optimization anti-pattern.

### 🎯 Why:
When using the Next.js `<Image>` component with the `fill` property without specifying `sizes`, Next.js defaults to assuming the image takes up the entire viewport width (`100vw`). This causes the browser to download unnecessarily large image sizes, wasting bandwidth and significantly slowing down the Largest Contentful Paint (LCP).

### 📊 Impact:
*   **Faster Load Times:** By specifying correct sizes, the browser downloads much smaller images tailored to the container's actual size on screen, improving loading times.
*   **Reduced Bandwidth:** Drastically reduces the bytes transferred over the network, particularly on mobile devices.
*   **Improved Core Web Vitals:** Contributes to a better LCP score.

### 🔬 Measurement:
1.  Run the application locally and open Chrome DevTools (Network tab).
2.  Filter by "Img".
3.  Navigate to the affected pages (landing page, convenios, equipe) and observe that the downloaded image file sizes are significantly smaller compared to running the application without this change. You can also run a Lighthouse report before and after to verify the LCP improvement.

---
*PR created automatically by Jules for task [7574983358550243675](https://jules.google.com/task/7574983358550243675) started by @mfelipperd*